### PR TITLE
Use `wasm-pack init` instead of `build`

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -73,7 +73,7 @@ function spawnWasmPack({ isDebug, cwd }) {
 
   const args = [
     '--verbose',
-    'build',
+    'init',
     '--target', 'browser',
     '--mode', 'no-install',
     ...(isDebug ? ['--debug'] : []),


### PR DESCRIPTION
Fixes #23.