### PR TITLE
add withTypescript option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ module.exports = {
   plugins: [
 
     new WasmPackPlugin({
-      crateDirectory: path.resolve(__dirname, "crate")
+      crateDirectory: path.resolve(__dirname, "crate"),
+      withTypescript: true
     }),
 
   ]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ module.exports = {
 
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "crate"),
-      withTypescript: true
+      withTypeScript: true
     }),
 
   ]

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -12,9 +12,8 @@ module.exports = {
     new HtmlWebpackPlugin(),
 
     new WasmPackPlugin({
-        crateDirectory: path.resolve(__dirname, "."),
-        withTypescript: true
+      crateDirectory: path.resolve(__dirname, "."),
+      withTypeScript: true
     }),
   ]
 };
-

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
     new HtmlWebpackPlugin(),
 
     new WasmPackPlugin({
-        crateDirectory: path.resolve(__dirname, ".")
+        crateDirectory: path.resolve(__dirname, "."),
+        withTypescript: true
     }),
   ]
 };

--- a/plugin.js
+++ b/plugin.js
@@ -30,7 +30,7 @@ let ranInitialCompilation = false;
 class WasmPackPlugin {
   constructor(options) {
     this.crateDirectory = options.crateDirectory;
-    this.withTypescript = options.withTypescript || false;
+    this.withTypeScript = options.withTypeScript || false;
 
     this.wp = new Watchpack();
     this.isDebug = true;
@@ -78,7 +78,7 @@ class WasmPackPlugin {
     return spawnWasmPack({
         isDebug: this.isDebug,
         cwd: this.crateDirectory,
-        withTypescript: this.withTypescript
+        withTypeScript: this.withTypeScript
       })
       .then(this._compilationSuccess)
       .catch(this._compilationFailure);
@@ -100,7 +100,7 @@ class WasmPackPlugin {
 function spawnWasmPack({
   isDebug,
   cwd,
-  withTypescript
+  withTypeScript
 }) {
   const bin = 'wasm-pack';
 
@@ -110,7 +110,7 @@ function spawnWasmPack({
     '--target', 'browser',
     '--mode', 'no-install',
     ...(isDebug ? ['--debug'] : []),
-    ...(withTypescript ? [] : ['--no-typescript'])
+    ...(withTypeScript ? [] : ['--no-typescript'])
   ];
 
   const options = {

--- a/plugin.js
+++ b/plugin.js
@@ -30,6 +30,7 @@ let ranInitialCompilation = false;
 class WasmPackPlugin {
   constructor(options) {
     this.crateDirectory = options.crateDirectory;
+    this.withTypescript = options.withTypescript || false;
 
     this.wp = new Watchpack();
     this.isDebug = true;
@@ -76,7 +77,8 @@ class WasmPackPlugin {
 
     return spawnWasmPack({
         isDebug: this.isDebug,
-        cwd: this.crateDirectory
+        cwd: this.crateDirectory,
+        withTypescript: this.withTypescript
       })
       .then(this._compilationSuccess)
       .catch(this._compilationFailure);
@@ -97,7 +99,8 @@ class WasmPackPlugin {
 
 function spawnWasmPack({
   isDebug,
-  cwd
+  cwd,
+  withTypescript
 }) {
   const bin = 'wasm-pack';
 
@@ -107,7 +110,7 @@ function spawnWasmPack({
     '--target', 'browser',
     '--mode', 'no-install',
     ...(isDebug ? ['--debug'] : []),
-    '--no-typescript' // usage is unknown, ignore for now
+    ...(withTypescript ? [] : ['--no-typescript'])
   ];
 
   const options = {


### PR DESCRIPTION
Add a `withTypescript` option to optionally generate `d.ts` files for the wasm module in order to integrate with typescript.

Example `tsconfig.json`

```js
{
    "compilerOptions": {
        "module": "esnext", // needed to have dynamic imports
        "lib": [
            "dom",
            "es2015"
        ]
    },
    "files": [
        "./index.ts"
    ]
}
```

Example `webpack.config.json`

```js
const path = require("path");
const HtmlWebpackPlugin = require("html-webpack-plugin");
const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");

module.exports = {
  entry: "./index.ts",
  output: {
    path: path.resolve(__dirname, "dist"),
    filename: "bundle.js"
  },
  plugins: [
    new HtmlWebpackPlugin(),

    new WasmPackPlugin({
      crateDirectory: path.resolve(__dirname, "."),
      withTypeScript: true
    }),
  ],
  resolve: {
    extensions: [".ts", ".tsx", ".js", ".wasm"]
  },
  module: {
    rules: [{
      test: /\.tsx?$/,
      loader: "ts-loader"
    }]
  }
};

```

Example `index.ts`

```typescript
import("./pkg/wasm_pack_test").then(module => {
  module.run();
});

```