### PR TITLE
fix(wasm-pack): don't use no-install by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ module.exports = {
 
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "crate"),
-      withTypeScript: true
+      withTypeScript: true, // false by default
+      noInstallMode: false, // false by default, it will avoid wasm-bindgen installation. Use it only if you know what you're doing!
     }),
 
   ]

--- a/plugin.js
+++ b/plugin.js
@@ -30,7 +30,8 @@ let ranInitialCompilation = false;
 class WasmPackPlugin {
   constructor(options) {
     this.crateDirectory = options.crateDirectory;
-    this.withTypeScript = options.withTypeScript || false;
+    this.withTypeScript = !!options.withTypeScript;
+    this.noInstallMode = !!options.noInstallMode
 
     this.wp = new Watchpack();
     this.isDebug = true;
@@ -78,7 +79,8 @@ class WasmPackPlugin {
     return spawnWasmPack({
         isDebug: this.isDebug,
         cwd: this.crateDirectory,
-        withTypeScript: this.withTypeScript
+        withTypeScript: this.withTypeScript,
+        noInstallMode: this.noInstallMode
       })
       .then(this._compilationSuccess)
       .catch(this._compilationFailure);
@@ -100,7 +102,8 @@ class WasmPackPlugin {
 function spawnWasmPack({
   isDebug,
   cwd,
-  withTypeScript
+  withTypeScript,
+  noInstallMode
 }) {
   const bin = 'wasm-pack';
 
@@ -108,7 +111,7 @@ function spawnWasmPack({
     '--verbose',
     'build',
     '--target', 'browser',
-    '--mode', 'no-install',
+    ...(noInstallMode ? ['--mode', 'no-install'] : []),
     ...(isDebug ? ['--debug'] : []),
     ...(withTypeScript ? [] : ['--no-typescript'])
   ];


### PR DESCRIPTION
Fixes #32 

Note that instead of removing it I've added the option for the user to opt-in to the `no-install` flag, which is still [present as an option](https://github.com/rustwasm/wasm-pack/blob/2ca946e8335528a8f5203d6a1971b8b1d2b1585c/src/command/build.rs#L40) in `wasm-pack`.

According to the [changelog](https://github.com/rustwasm/wasm-pack/blob/master/CHANGELOG.md#%EF%B8%8F-050) this is still the fastest option if you know what you're doing.