### PR TITLE
Keep the environment of the parent process intact

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -114,10 +114,7 @@ function spawnWasmPack({
   ];
 
   const options = {
-    cwd,
-    env: {
-      PATH: process.env['PATH']
-    }
+    cwd
   };
 
   return runProcess(bin, args, options);


### PR DESCRIPTION
This is important so crucial env variables like CARGO_HOME are preserved properly.

Fixes issue #39 