### PR TITLE
Allow configure-time watch mode for wasm-pack independent of webpack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ module.exports = {
       // Default arguments are `--typescript --target browser --mode normal`.
       extraArgs: "--no-typescript",
 
-      // If enabled, `watch` will always compile changes in `.rs` files, even
-      // if Webpack is not running in watch mode. Conversely, changing this to
-      // `false` will disable watch mode, even if Webpack is running in watch
-      // mode.
-      watch: true,
+      // If defined, `forceWatch` will force activate/deactivate watch mode for
+      // `.rs` files.
+      //
+      // The default (not set) aligns watch mode for `.rs` files to Webpack's
+      // watch mode.
+      // forceWatch: true,
     }),
 
   ]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ module.exports = {
       //
       // Default arguments are `--typescript --target browser --mode normal`.
       extraArgs: "--no-typescript",
+
+      // If enabled, `watch` will always compile changes in `.rs` files, even
+      // if Webpack is not running in watch mode. Conversely, changing this to
+      // `false` will disable watch mode, even if Webpack is running in watch
+      // mode.
+      watch: true,
     }),
 
   ]

--- a/plugin.js
+++ b/plugin.js
@@ -30,6 +30,7 @@ let ranInitialCompilation = false;
 class WasmPackPlugin {
   constructor(options) {
     this.crateDirectory = options.crateDirectory;
+    this.watch = options.watch;
     this.extraArgs = (options.extraArgs || '').trim().split(' ').filter(x=> x);
 
     this.wp = new Watchpack();
@@ -52,7 +53,7 @@ class WasmPackPlugin {
         .catch(this._compilationFailure);
     });
 
-    if (compiler.watchMode) {
+    if (this.watch || (this.watch === undefined && compiler.watchMode)) {
       const files = glob.sync(join(this.crateDirectory, '**', '*.rs'));
 
       this.wp.watch(files, [], Date.now() - 10000);

--- a/plugin.js
+++ b/plugin.js
@@ -2,15 +2,8 @@ const {
   spawn
 } = require('child_process');
 const {
-  join,
-  dirname
+  join
 } = require('path');
-const {
-  writeFileSync,
-  mkdirSync,
-  existsSync,
-  unlinkSync
-} = require('fs');
 const commandExistsSync = require('command-exists').sync;
 const chalk = require('chalk');
 const Watchpack = require('watchpack');
@@ -30,7 +23,7 @@ let ranInitialCompilation = false;
 class WasmPackPlugin {
   constructor(options) {
     this.crateDirectory = options.crateDirectory;
-    this.watch = options.watch;
+    this.forceWatch = options.forceWatch;
     this.extraArgs = (options.extraArgs || '').trim().split(' ').filter(x=> x);
 
     this.wp = new Watchpack();
@@ -53,7 +46,7 @@ class WasmPackPlugin {
         .catch(this._compilationFailure);
     });
 
-    if (this.watch || (this.watch === undefined && compiler.watchMode)) {
+    if (this.forceWatch || (this.forceWatch === undefined && compiler.watchMode)) {
       const files = glob.sync(join(this.crateDirectory, '**', '*.rs'));
 
       this.wp.watch(files, [], Date.now() - 10000);


### PR DESCRIPTION
Sometimes, inheriting the webpack compiler's watch mode isn't exactly what we want when building a dependency with `wasm-pack`. (As an example, many advanced HMR implementations set up a separate watcher for changes in certain directories and implement a custom watcher, such as the one used in `electron-webpack`.)

For my project, it's very helpful to be able to watch `.rs` files on-demand, regardless of if the `webpack` watcher is on. I thought perhaps an option that turns "watch mode" on and off (which is a noop deferring to `webpack` if not specified) would make the most sense for this, but please let me know if you have a better idea!