### PR TITLE
fix: Watch mode for Rust files

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -46,7 +46,7 @@ class WasmPackPlugin {
         .catch(this._compilationFailure);
     });
 
-    if (this.forceWatch || (this.forceWatch === undefined && compiler.watch)) {
+    if (this.forceWatch || (this.forceWatch === undefined && compiler.options.watch)) {
       const files = glob.sync(join(this.crateDirectory, '**', '*.rs'));
 
       this.wp.watch(files, [], Date.now() - 10000);

--- a/plugin.js
+++ b/plugin.js
@@ -46,7 +46,7 @@ class WasmPackPlugin {
         .catch(this._compilationFailure);
     });
 
-    if (this.forceWatch || (this.forceWatch === undefined && compiler.options.watch)) {
+    if (this.isDebug && (this.forceWatch || (this.forceWatch === undefined && compiler.options.watch))) {
       const files = glob.sync(join(this.crateDirectory, '**', '*.rs'));
 
       this.wp.watch(files, [], Date.now() - 10000);

--- a/plugin.js
+++ b/plugin.js
@@ -46,7 +46,7 @@ class WasmPackPlugin {
         .catch(this._compilationFailure);
     });
 
-    if (this.forceWatch || (this.forceWatch === undefined && compiler.watchMode)) {
+    if (this.forceWatch || (this.forceWatch === undefined && compiler.watch)) {
       const files = glob.sync(join(this.crateDirectory, '**', '*.rs'));
 
       this.wp.watch(files, [], Date.now() - 10000);


### PR DESCRIPTION
This will check for `watch` instead of `watchMode` since `watchMode` isn't a valid configuration. This will resolve this issue: https://github.com/rustwasm/rust-webpack-template/issues/69.