### PR TITLE
fix: watch for files

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -42,16 +42,17 @@ class WasmPackPlugin {
       ranInitialCompilation = true;
 
       return this._checkWasmPack()
-        .then(() => this._compile())
+        .then(() => {
+            if (this.forceWatch || (this.forceWatch === undefined && compiler.watchMode)) {
+              const files = glob.sync(join(this.crateDirectory, '**', '*.rs'));
+
+              this.wp.watch(files, [], Date.now() - 10000);
+              this.wp.on('change', this._compile.bind(this));
+            }
+          return this._compile()
+        })
         .catch(this._compilationFailure);
     });
-
-    if (this.forceWatch || (this.forceWatch === undefined && compiler.watchMode)) {
-      const files = glob.sync(join(this.crateDirectory, '**', '*.rs'));
-
-      this.wp.watch(files, [], Date.now() - 10000);
-      this.wp.on('change', this._compile.bind(this));
-    }
   }
 
   _checkWasmPack() {

--- a/plugin.js
+++ b/plugin.js
@@ -49,7 +49,7 @@ class WasmPackPlugin {
               this.wp.watch(files, [], Date.now() - 10000);
               this.wp.on('change', this._compile.bind(this));
             }
-          return this._compile()
+            return this._compile()
         })
         .catch(this._compilationFailure);
     });


### PR DESCRIPTION
The compiler is not initialized when the check is happening. Moving this inside the hook, ensures that the compiler is actually initialized correctly with default values.

Locally it works.

Closes #43 

r? @xtuc  {Probably release a version once it is merged}