### PR TITLE
Watch `src` dir instead of individual files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "command-exists": "^1.2.7",
-    "glob": "^7.1.2",
     "watchpack": "^1.6.0"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -7,7 +7,6 @@ const {
 const commandExistsSync = require('command-exists').sync;
 const chalk = require('chalk');
 const Watchpack = require('watchpack');
-const glob = require('glob');
 
 const error = msg => console.log(chalk.bold.red(msg));
 const info = msg => console.log(chalk.bold.blue(msg));
@@ -44,12 +43,12 @@ class WasmPackPlugin {
       return this._checkWasmPack()
         .then(() => {
             if (this.forceWatch || (this.forceWatch === undefined && compiler.watchMode)) {
-              const files = glob.sync(join(this.crateDirectory, '**', '*.rs'));
+              const dirs = [join(this.crateDirectory, 'src')];
 
-              this.wp.watch(files, [], Date.now() - 10000);
+              this.wp.watch([], dirs, Date.now() - 10000);
               this.wp.on('change', this._compile.bind(this));
             }
-            return this._compile()
+            return this._compile();
         })
         .catch(this._compilationFailure);
     });


### PR DESCRIPTION
**Problem:** The watcher is set up only once during the initial compilation (because of `ranInitialCompilation` flag) and thus won't pick up any new/renamed files inside the crate's `src/` dir.

**Solution:** Set up the watcher to monitor the `src/` dir instead of individual `*.rs` files.