### PR TITLE
Configurable watch list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,17 @@ module.exports = {
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "crate"),
 
-      // List of directories changes to which will trigger the build.
-      //
-      // If omitted, only the crate's `src/` directory will be monitored for
-      // changes. Otherwise this should be an array of absolute paths.
-      watchDirectories: [
-        path.resolve(__dirname, "crate/src"),
-        path.resolve(__dirname, "another-crate/src")
-      ],
-
       // Check https://rustwasm.github.io/wasm-pack/book/commands/build.html for
       // the available set of arguments.
       //
       // Default arguments are `--typescript --target browser --mode normal`.
       extraArgs: "--no-typescript",
+
+      // Optional array of absolute paths to directories, changes to which
+      // will trigger the build.
+      // watchDirectories: [
+      //   path.resolve(__dirname, "another-crate/src")
+      // ],
 
       // If defined, `forceWatch` will force activate/deactivate watch mode for
       // `.rs` files.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ module.exports = {
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "crate"),
 
+      // List of extra directories to watch, relative to the `crateDirectory`.
+      //
+      // By default, only the crate's `src/` directory will be monitored for
+      // changes. Here you can specify extra directories that you want to trigger
+      // build.
+      watchDirectories: [
+        '../extra-crate-to-watch/src'
+      ],
+
       // Check https://rustwasm.github.io/wasm-pack/book/commands/build.html for
       // the available set of arguments.
       //

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ module.exports = {
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "crate"),
 
-      // List of extra directories to watch, relative to the `crateDirectory`.
+      // List of directories changes to which will trigger the build.
       //
-      // By default, only the crate's `src/` directory will be monitored for
-      // changes. Here you can specify extra directories that you want to trigger
-      // build.
+      // If omitted, only the crate's `src/` directory will be monitored for
+      // changes. Otherwise this should be an array of absolute paths.
       watchDirectories: [
-        '../extra-crate-to-watch/src'
+        path.resolve(__dirname, "crate/src"),
+        path.resolve(__dirname, "another-crate/src")
       ],
 
       // Check https://rustwasm.github.io/wasm-pack/book/commands/build.html for

--- a/plugin.js
+++ b/plugin.js
@@ -23,9 +23,16 @@ class WasmPackPlugin {
     this.forceWatch = options.forceWatch;
     this.forceMode = options.forceMode;
     this.extraArgs = (options.extraArgs || '').trim().split(' ').filter(x=> x);
-    this.watchDirectories = (options.watchDirectories || [])
-      .concat('src')
-      .map(dir => path.resolve(this.crateDirectory, dir));
+
+    if (options.watchDirectories) {
+      // Assume that `watchDirectories` here are absolute paths and
+      // don't need to be resolved.
+      this.watchDirectories = options.watchDirectories;
+    } else {
+      // If `watchDirectories` is empty, we should watch only
+      // the crate's `src/` directory.
+      this.watchDirectories = [path.resolve(this.crateDirectory, 'src')];
+    }
 
     this.wp = new Watchpack();
     this.isDebug = true;

--- a/plugin.js
+++ b/plugin.js
@@ -1,9 +1,7 @@
 const {
   spawn
 } = require('child_process');
-const {
-  join
-} = require('path');
+const path = require('path');
 const commandExistsSync = require('command-exists').sync;
 const chalk = require('chalk');
 const Watchpack = require('watchpack');
@@ -25,6 +23,9 @@ class WasmPackPlugin {
     this.forceWatch = options.forceWatch;
     this.forceMode = options.forceMode;
     this.extraArgs = (options.extraArgs || '').trim().split(' ').filter(x=> x);
+    this.watchDirectories = (options.watchDirectories || [])
+      .concat('src')
+      .map(dir => path.resolve(this.crateDirectory, dir));
 
     this.wp = new Watchpack();
     this.isDebug = true;
@@ -44,9 +45,7 @@ class WasmPackPlugin {
       return this._checkWasmPack()
         .then(() => {
             if (this.forceWatch || (this.forceWatch === undefined && compiler.watchMode)) {
-              const dirs = [join(this.crateDirectory, 'src')];
-
-              this.wp.watch([], dirs, Date.now() - 10000);
+              this.wp.watch([], this.watchDirectories, Date.now() - 10000);
               this.wp.on('change', this._compile.bind(this));
             }
             return this._compile();

--- a/plugin.js
+++ b/plugin.js
@@ -23,16 +23,8 @@ class WasmPackPlugin {
     this.forceWatch = options.forceWatch;
     this.forceMode = options.forceMode;
     this.extraArgs = (options.extraArgs || '').trim().split(' ').filter(x=> x);
-
-    if (options.watchDirectories) {
-      // Assume that `watchDirectories` here are absolute paths and
-      // don't need to be resolved.
-      this.watchDirectories = options.watchDirectories;
-    } else {
-      // If `watchDirectories` is empty, we should watch only
-      // the crate's `src/` directory.
-      this.watchDirectories = [path.resolve(this.crateDirectory, 'src')];
-    }
+    this.watchDirectories = (options.watchDirectories || [])
+      .concat(path.resolve(this.crateDirectory, 'src'));
 
     this.wp = new Watchpack();
     this.isDebug = true;


### PR DESCRIPTION
**Problem:** Currently the watcher is set up to monitor only the main crate's `src/` directory and in case you're working on a few interdependent packages at the same time, there's no way to trigger build on changes to any of the secondary crates.

**Solution:** Allow customizing the directory watch list.