### PR TITLE
fix for when multiple configs are exported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wasm-tool/wasm-pack-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Webpack plugin for Rust",
   "main": "plugin.js",
   "directories": {

--- a/plugin.js
+++ b/plugin.js
@@ -9,16 +9,15 @@ const Watchpack = require('watchpack');
 const error = msg => console.log(chalk.bold.red(msg));
 const info = msg => console.log(chalk.bold.blue(msg));
 
-/**
- * In some cases Webpack will require the pkg entrypoint before it actually
- * exists. To mitigate that we are forcing a first compilation.
- *
- * See https://github.com/wasm-tool/wasm-pack-plugin/issues/15
- */
-let ranInitialCompilation = false;
-
 class WasmPackPlugin {
   constructor(options) {
+    /**
+     * In some cases Webpack will require the pkg entrypoint before it actually
+     * exists. To mitigate that we are forcing a first compilation.
+     *
+     * See https://github.com/wasm-tool/wasm-pack-plugin/issues/15
+     */
+    this.ranInitialCompilation = false;
     this.crateDirectory = options.crateDirectory;
     this.forceWatch = options.forceWatch;
     this.forceMode = options.forceMode;
@@ -35,11 +34,11 @@ class WasmPackPlugin {
 
     // force first compilation
     compiler.hooks.beforeCompile.tapPromise('WasmPackPlugin', () => {
-      if (ranInitialCompilation === true) {
+      if (this.ranInitialCompilation === true) {
         return Promise.resolve();
       }
 
-      ranInitialCompilation = true;
+      this.ranInitialCompilation = true;
 
       return this._checkWasmPack()
         .then(() => {

--- a/plugin.js
+++ b/plugin.js
@@ -17,7 +17,7 @@ class WasmPackPlugin {
      *
      * See https://github.com/wasm-tool/wasm-pack-plugin/issues/15
      */
-    this.ranInitialCompilation = false;
+    this._ranInitialCompilation = false;
     this.crateDirectory = options.crateDirectory;
     this.forceWatch = options.forceWatch;
     this.forceMode = options.forceMode;
@@ -34,11 +34,11 @@ class WasmPackPlugin {
 
     // force first compilation
     compiler.hooks.beforeCompile.tapPromise('WasmPackPlugin', () => {
-      if (this.ranInitialCompilation === true) {
+      if (this._ranInitialCompilation === true) {
         return Promise.resolve();
       }
 
-      this.ranInitialCompilation = true;
+      this._ranInitialCompilation = true;
 
       return this._checkWasmPack()
         .then(() => {


### PR DESCRIPTION
Closes #49 and bumps the version to `0.2.2`