### PR TITLE
added error listener

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -134,6 +134,8 @@ function runProcess(bin, args, options) {
         reject(stderr);
       }
     });
+
+    p.on('error', reject);
   });
 }
 


### PR DESCRIPTION
This is a 1-line change to avoid errors like this:

![image](https://user-images.githubusercontent.com/77758/51942874-21524200-23e6-11e9-85ce-13b3112358b1.png)

Since this is a very small change I didn't bump the version number in case you wanted to include this in a larger release.