### PR TITLE
Use build flag "--dev" instead of "--debug"

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -101,7 +101,7 @@ function spawnWasmPack({
   const args = [
     '--verbose',
     'build',
-    ...(isDebug ? ['--debug'] : []),
+    ...(isDebug ? ['--dev'] : []),
     ...extraArgs,
   ];
 


### PR DESCRIPTION
Looks like in the [`v0.6.0`](https://github.com/rustwasm/wasm-pack/releases/tag/v0.6.0) release the `--debug` flag was deprecated in favor of `--dev`.