### PR TITLE
Add message indicating when crate is compiled in development mode

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -67,7 +67,7 @@ class WasmPackPlugin {
   }
 
   _compile() {
-    info(`ℹ️  Compiling your crate ${this.isDebug ? 'in development mode' : ''}...\n`);
+    info(`ℹ️  Compiling your crate in ${this.isDebug ? 'development' : 'release'} mode...\n`);
 
     return spawnWasmPack({
         isDebug: this.isDebug,

--- a/plugin.js
+++ b/plugin.js
@@ -67,7 +67,7 @@ class WasmPackPlugin {
   }
 
   _compile() {
-    info('ℹ️  Compiling your crate...\n');
+    info(`ℹ️  Compiling your crate ${this.isDebug ? 'in development mode' : ''}...\n`);
 
     return spawnWasmPack({
         isDebug: this.isDebug,


### PR DESCRIPTION
Refs https://github.com/rustwasm/rust-webpack-template/issues/116

The `wasm-pack` tool [builds in release mode by default](https://rustwasm.github.io/wasm-pack/book/commands/build.html#profile), so when the wasm-pack-plugin defaults to development mode it can be confusing for uses (see https://github.com/rustwasm/rust-webpack-template/issues/116).

This adds a message so that the console will clearly display when the crate is being compiled in development mode.