### PR TITLE
Add Type Declarations for Webpack configurations written in TypeScript.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.5",
   "description": "Webpack plugin for Rust",
   "main": "plugin.js",
+  "types": "plugin.d.ts",
   "directories": {
     "example": "example"
   },
@@ -29,5 +30,8 @@
     "chalk": "^2.4.1",
     "command-exists": "^1.2.7",
     "watchpack": "^1.6.0"
+  },
+  "devDependencies": {
+    "@types/webpack": "*"
   }
 }

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,0 +1,15 @@
+import { Plugin } from 'webpack';
+
+declare module '@wasm-tool/wasm-pack-plugin' {
+    export interface WasmPackPluginOptions {
+        crateDirectory: string;
+        extraArgs?: string;
+        watchDirectories?: string[];
+        forceWatch?: boolean;
+        forceMode?: 'development' | 'production';
+    }
+
+    export default class WasmPackPlugin extends Plugin {
+        constructor(options: WasmPackPluginOptions)
+    }
+}


### PR DESCRIPTION
This PR adds a simple TypeScript declaration file to allow this module to be used in TypeScript projects with type-safety. I just based it off the documentation in the README, but it's been good enough for me in local projects.