### PR TITLE
Use console.error instead of console.log

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -7,8 +7,8 @@ const commandExistsSync = require('command-exists').sync;
 const chalk = require('chalk');
 const Watchpack = require('watchpack');
 
-const error = msg => console.log(chalk.bold.red(msg));
-const info = msg => console.log(chalk.bold.blue(msg));
+const error = msg => console.error(chalk.bold.red(msg));
+const info = msg => console.error(chalk.bold.blue(msg));
 // https://github.com/wasm-tool/wasm-pack-plugin/issues/58
 const wasmPackPath = process.env["WASM_PACK_PATH"];
 


### PR DESCRIPTION
when using `webpack --json`, using `console.log` makes the json unusable. So I changed the logging to log to stderr, which works well in this regard.