### PR TITLE
docs: fix installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ yarn add --dev @wasm-tool/wasm-pack-plugin
 
 ### `wasm-pack`
 
-We expect `wasm-pack` to be in your `$PATH`. See [installation here](https://github.com/rustwasm/wasm-pack/blob/master/docs/src/setup.md#installing-wasm-pack).
+We expect `wasm-pack` to be in your `$PATH`. See [installation here](https://rustwasm.github.io/wasm-pack/installer).
 
 The minimum required `wasm-pack` version is `0.8.0`
 


### PR DESCRIPTION
Hi, developers.

The installation link, <https://github.com/rustwasm/wasm-pack/blob/master/docs/src/setup.md#installing-wasm-pack> is "Page not found". So, I replace it with <https://rustwasm.github.io/wasm-pack/installer/>.