### PR TITLE
Make empty pkg dir in crateDirectory

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -86,15 +86,16 @@ class WasmPackPlugin {
   }
 
   _makeEmpty() {
+	  const outPath = path.join(this.crateDirectory, this.outDir);
     try {
-      fs.mkdirSync(this.outDir);
+      fs.mkdirSync(outPath);
     } catch (e) {
       if (e.code !== "EEXIST") {
         throw e;
       }
     }
 
-    fs.writeFileSync(path.join(this.outDir, this.outName + ".js"), "");
+    fs.writeFileSync(path.join(outPath, this.outName + ".js"), "");
   }
 
   _checkWasmPack() {


### PR DESCRIPTION
Not totally sure I understand the point of `_makeEmpty()`, but it creates a `pkg` directory in my project root when my Rust/WASM project is in a subdirectory - where another `pkg` directory is created anyway.
This pull request creates the `pkg` directory inside the directory specified by `crateDirectory`, reducing clutter in the project root when the wasm project is in a different directory.