### PR TITLE
ts: declare outDir and outName in options

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -4,9 +4,11 @@ declare module '@wasm-tool/wasm-pack-plugin' {
     export interface WasmPackPluginOptions {
         crateDirectory: string;
         extraArgs?: string;
-        watchDirectories?: string[];
         forceWatch?: boolean;
         forceMode?: 'development' | 'production';
+        outDir?: string;
+        outName?: string;
+        watchDirectories?: string[];
     }
 
     export default class WasmPackPlugin extends Plugin {


### PR DESCRIPTION
Missing `outDir` and `outName` in `plugin.d.ts`