### PR TITLE
Fix(pkg output): Fix the pkg output path

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -26,6 +26,11 @@ class WasmPackPlugin {
     this.forceMode = options.forceMode;
     this.extraArgs = (options.extraArgs || '').trim().split(' ').filter(x => x);
     this.outDir = options.outDir || "pkg";
+    if(!path.isAbsolute(this.outDir)) {
+      // Fix the problem that the wasm-pack treat the Cargo.toml as the root dir
+      this.outDir = path.resolve(process.cwd(), this.outDir)
+    }
+
     this.outName = options.outName || "index";
     this.watchDirectories = (options.watchDirectories || [])
       .concat(path.resolve(this.crateDirectory, 'src'));


### PR DESCRIPTION
Fix the problem when outDir is a relative path, wasm-pack will use
Cargo.toml as root path, but this._makeEmpty will use package.json

### for example
**webpack.config.js:**
```javascript
    new WasmPackPlugin({
      crateDirectory: path.resolve(__dirname, "./src/native"),
      outDir: "./source/pkg",
    }),
```

without the patch, extra index.js will be generated.
> ./source/pkg/index.js (empty file)
> ./src/native/source/pkg/xxxx (actual files)
