### PR TITLE
[feature] allow pre-command arguments to be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ module.exports = {
       // Check https://rustwasm.github.io/wasm-pack/book/commands/build.html for
       // the available set of arguments.
       //
+      // Optional space delimited arguments to appear before the wasm-pack
+      // command. Default arguments are `--verbose`.
+      args: "--log-level warn",
       // Default arguments are `--typescript --target browser --mode normal`.
       extraArgs: "--no-typescript",
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -3,6 +3,7 @@ import { Plugin } from 'webpack';
 declare module '@wasm-tool/wasm-pack-plugin' {
     export interface WasmPackPluginOptions {
         crateDirectory: string;
+        args?: string;
         extraArgs?: string;
         forceWatch?: boolean;
         forceMode?: 'development' | 'production';

--- a/plugin.js
+++ b/plugin.js
@@ -24,6 +24,7 @@ class WasmPackPlugin {
     this.crateDirectory = options.crateDirectory;
     this.forceWatch = options.forceWatch;
     this.forceMode = options.forceMode;
+    this.args = (options.args || '--verbose').trim().split(' ').filter(x => x);
     this.extraArgs = (options.extraArgs || '').trim().split(' ').filter(x => x);
     this.outDir = options.outDir || "pkg";
     this.outName = options.outName || "index";
@@ -137,6 +138,7 @@ class WasmPackPlugin {
         outName: this.outName,
         isDebug: this.isDebug,
         cwd: this.crateDirectory,
+        args: this.args,
         extraArgs: this.extraArgs,
       });
     }).then((detail) => {
@@ -167,12 +169,13 @@ function spawnWasmPack({
   outName,
   isDebug,
   cwd,
+  args,
   extraArgs
 }) {
   const bin = wasmPackPath || 'wasm-pack';
 
-  const args = [
-    '--verbose',
+  const allArgs = [
+    ...args,
     'build',
     '--out-dir', outDir,
     '--out-name', outName,
@@ -185,7 +188,7 @@ function spawnWasmPack({
     stdio: "inherit"
   };
 
-  return runProcess(bin, args, options);
+  return runProcess(bin, allArgs, options);
 }
 
 function runProcess(bin, args, options) {


### PR DESCRIPTION
Allow wasm-pack command line parameters to be specified and passed. When
unspecified, continue to default to `--verbose` to avoid a breaking
change.

fix #79