### PR TITLE
[feature] expose plugin logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ module.exports = {
       // the mode `development` makes `wasm-pack` build in `debug` mode.
       // the mode `production` makes `wasm-pack` build in `release` mode.
       // forceMode: "development",
+      //
+      // Controls plugin output verbosity, either 'info' or 'error'.
+      // Defaults to 'info'.
+      // pluginLogLevel: 'info'
     }),
 
   ]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ module.exports = {
       // the mode `development` makes `wasm-pack` build in `debug` mode.
       // the mode `production` makes `wasm-pack` build in `release` mode.
       // forceMode: "development",
-      //
+ 
       // Controls plugin output verbosity, either 'info' or 'error'.
       // Defaults to 'info'.
       // pluginLogLevel: 'info'

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -10,6 +10,8 @@ declare module '@wasm-tool/wasm-pack-plugin' {
         outDir?: string;
         outName?: string;
         watchDirectories?: string[];
+        /** Controls plugin output verbosity. Defaults to 'info'. */
+        pluginLogLevel: 'info' | 'error';
     }
 
     export default class WasmPackPlugin extends Plugin {

--- a/plugin.js
+++ b/plugin.js
@@ -8,7 +8,7 @@ const chalk = require('chalk');
 const Watchpack = require('watchpack');
 
 const error = msg => console.error(chalk.bold.red(msg));
-const info = msg => console.log(chalk.bold.blue(msg));
+let info = msg => console.log(chalk.bold.blue(msg));
 // https://github.com/wasm-tool/wasm-pack-plugin/issues/58
 const wasmPackPath = process.env["WASM_PACK_PATH"];
 
@@ -31,6 +31,13 @@ class WasmPackPlugin {
     this.watchDirectories = (options.watchDirectories || [])
       .concat(path.resolve(this.crateDirectory, 'src'));
     this.watchFiles = [path.resolve(this.crateDirectory, 'Cargo.toml')];
+
+    if (options.pluginLogLevel && options.pluginLogLevel !== 'info') {
+      // The default value for pluginLogLevel is 'info'. If specified and it's
+      // not 'info', don't log informational messages. If unspecified or 'info',
+      // log as per usual.
+      info = () => {};
+    }
 
     this.wp = new Watchpack();
     this.isDebug = true;


### PR DESCRIPTION
Allow wasm-pack-plugin's output level to controlled via a new
configuration, pluginLogLevel. Valid values are 'info' (the default) or
'error'. The former maintains the status quo and the latter only reports
serious errors.

The rationale for this change is that Webpack itself can be quite
verbose, to a fault even. Once the scaffolding for a wasm-pack-plugin
based project is up and running smoothly, the additional plugin's
informational messaging is less useful in combination with Webpack's
logging. This gives clients a choice in how much to log and where.

fix #83