### PR TITLE
Make pluginLogLevel an optional config option

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -11,7 +11,7 @@ declare module '@wasm-tool/wasm-pack-plugin' {
         outName?: string;
         watchDirectories?: string[];
         /** Controls plugin output verbosity. Defaults to 'info'. */
-        pluginLogLevel: 'info' | 'error';
+        pluginLogLevel?: 'info' | 'error';
     }
 
     export default class WasmPackPlugin extends Plugin {


### PR DESCRIPTION
As defined, this is a required config option in the TypeScript definition, but appears to be an optional config option in the actual source code.