### PR TITLE
Fix plugin.d.ts exported type declarations

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,20 +1,26 @@
 import { Plugin } from 'webpack';
 
-declare module '@wasm-tool/wasm-pack-plugin' {
-    export interface WasmPackPluginOptions {
-        crateDirectory: string;
-        args?: string;
-        extraArgs?: string;
-        forceWatch?: boolean;
-        forceMode?: 'development' | 'production';
-        outDir?: string;
-        outName?: string;
-        watchDirectories?: string[];
-        /** Controls plugin output verbosity. Defaults to 'info'. */
-        pluginLogLevel?: 'info' | 'error';
-    }
+export interface WasmPackPluginOptions {
+    crateDirectory: string;
+    args?: string;
+    extraArgs?: string;
+    forceWatch?: boolean;
+    forceMode?: 'development' | 'production';
+    outDir?: string;
+    outName?: string;
+    watchDirectories?: string[];
+    /** Controls plugin output verbosity. Defaults to 'info'. */
+    pluginLogLevel?: 'info' | 'error';
+}
 
-    export default class WasmPackPlugin extends Plugin {
-        constructor(options: WasmPackPluginOptions)
-    }
+export default class WasmPackPlugin extends Plugin {
+    constructor(options: WasmPackPluginOptions)
+}
+
+export = WasmPackPlugin
+
+declare module '@wasm-tool/wasm-pack-plugin' {
+    export { WasmPackPluginOptions, WasmPackPlugin }
+    export default WasmPackPlugin
+    export = WasmPackPlugin
 }


### PR DESCRIPTION
The current declaration file is written like an ambient declaration file, when it should be written as a type definition of the plugin.js (`package [main]`) file.

This makes it both useable as an ambient declaration and fixes it for normal imports.