### PR TITLE
Fix creating empty pkg dir with crate parent dir

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -94,15 +94,16 @@ class WasmPackPlugin {
   }
 
   _makeEmpty() {
+    const outDir = path.resolve(this.crateDirectoy, this.outDir);
     try {
-      fs.mkdirSync(this.outDir);
+      fs.mkdirSync(outDir);
     } catch (e) {
       if (e.code !== "EEXIST") {
         throw e;
       }
     }
 
-    fs.writeFileSync(path.join(this.outDir, this.outName + ".js"), "");
+    fs.writeFileSync(path.join(outDir, this.outName + ".js"), "");
   }
 
   _checkWasmPack() {

--- a/plugin.js
+++ b/plugin.js
@@ -94,7 +94,7 @@ class WasmPackPlugin {
   }
 
   _makeEmpty() {
-    const outDir = path.resolve(this.crateDirectoy, this.outDir);
+    const outDir = path.resolve(this.crateDirectory, this.outDir);
     try {
       fs.mkdirSync(outDir);
     } catch (e) {


### PR DESCRIPTION
When crateDirectory is not ".", `_makeEmpty` seems to create the empty pkg directory in current working directory, instead of `this.crateDirectory`. This fix just prepends `this.crateDirectory` when making the empty pkg dir.