### PR TITLE
move which to dependencies fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "command-exists": "^1.2.7",
-    "watchpack": "^1.6.0"
+    "watchpack": "^1.6.0",
+    "which": "^2.0.2"
   },
   "devDependencies": {
-    "@types/webpack": "*",
-    "which": "^2.0.2"
+    "@types/webpack": "*"
   }
 }


### PR DESCRIPTION
`which` is required to run `wasm-pack-plugin`, so it must be listed as `dependencies` instead of `devDependencies`. npm/yarn don't install the devDependencies of packages, see https://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencies