### PR TITLE
Switch watcher event to `aggregated` to avoid compile corruption on file changes from FTP.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -81,7 +81,7 @@ class WasmPackPlugin {
           if (shouldWatch) {
             this.wp.watch(this.watchFiles, this.watchDirectories, Date.now() - 10000);
 
-            this.wp.on('change', () => {
+            this.wp.on('aggregated', () => {
               this._compile(true);
             });
           }


### PR DESCRIPTION
Use the `'aggregated'` watch event rather than `'change'` to group together multiple changes in rapid succession, avoiding multiple simultaneous recompiles (and subsequent corruption) when using FTP or other weird file modifications.