### PR TITLE
Update webpack type declarations for webpack 5

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'webpack';
+import { Compiler } from 'webpack';
 
 export interface WasmPackPluginOptions {
     crateDirectory: string;
@@ -13,8 +13,11 @@ export interface WasmPackPluginOptions {
     pluginLogLevel?: 'info' | 'error';
 }
 
-export default class WasmPackPlugin extends Plugin {
+export default class WasmPackPlugin {
     constructor(options: WasmPackPluginOptions)
+    
+    /** Invocation point for webpack plugins. */
+    apply(compiler: Compiler): void;
 }
 
 export = WasmPackPlugin


### PR DESCRIPTION
It looks like sometime around webpack 5, the `Plugin` abstract class was renamed. There's a couple ways to patch this up, but based off internal webpack examples (like https://github.com/webpack/webpack/blob/master/types.d.ts#L163), this seems to be in line with how webpack declares their own internal plugins to match their `WebpackPluginInstance` interface.