### PR TITLE
Prevent automatic global installation of wasm-pack

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -133,18 +133,9 @@ class WasmPackPlugin {
       return true;
     }
 
-    info('ℹ️  Installing wasm-pack \n');
+    error('⚠️  Could not find wasm-pack\n   Please install it via `yarn add -D wasm-pack`, `npm install --dev wasm-pack` or by following the instructions at: https://rustwasm.github.io/wasm-pack/installer/');
 
-    if (commandExistsSync("npm")) {
-      return runProcess("npm", ["install", "-g", "wasm-pack"], {});
-    } else if (commandExistsSync("yarn")) {
-      return runProcess("yarn", ["global", "add", "wasm-pack"], {});
-    } else {
-      error(
-        "⚠️ could not install wasm-pack, you must have yarn or npm installed"
-      );
-    }
-    return false
+    return false;
   }
 
   _compile(watching) {


### PR DESCRIPTION
Installing software globally on a developers' machine as a side-effect of using a webpack plugin is generally a bad idea, especially when they are not informed that this will take place. Instead, it's better to provide instructions as to how someone can install the relevant software, and allow a user to choose.

Automatic installation can also be problematic in certain CI environments where there are stricter security requirements.

This automatic installation was added in: https://github.com/wasm-tool/wasm-pack-plugin/commit/aea762a0cfa0d6a6afa22fb39691f47b989d9281