### PR TITLE
Recursively create output directory

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -123,7 +123,7 @@ class WasmPackPlugin {
 
     _makeEmpty() {
         try {
-            fs.mkdirSync(this.outDir)
+            fs.mkdirSync(this.outDir, {recursive: true})
         } catch (e) {
             if (e.code !== 'EEXIST') {
                 throw e


### PR DESCRIPTION
Creates parent dirs of output directory if necessary. This makes the behavior consistent with the
rest of Webpack (for example, the `output.path` config setting creates parent dirs as needed).