### PR TITLE
add pnpm as a package manager for isntalling the wasm-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Or with Yarn:
 yarn add --dev @wasm-tool/wasm-pack-plugin
 ```
 
+Or with Pnpm:
+```sh
+pnpm add -D @wasm-tool/wasm-pack-plugin
+```
+
 ### `wasm-pack`
 
 We expect `wasm-pack` to be in your `$PATH`. See [installation here](https://rustwasm.github.io/wasm-pack/installer).

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ module.exports = {
  
       // Controls plugin output verbosity, either 'info' or 'error'.
       // Defaults to 'info'.
-      // pluginLogLevel: 'info'
+      // pluginLogLevel: 'info',
+      // // Controls which package manager will be used to install the wasm-pack.
+      // packageManager: 'npm', //Options are [npm|yarn|pnpm]
     }),
 
   ]

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -11,6 +11,7 @@ export interface WasmPackPluginOptions {
     watchDirectories?: string[];
     /** Controls plugin output verbosity. Defaults to 'info'. */
     pluginLogLevel?: 'info' | 'error';
+    packageManager: 'npm' | 'yarn' | 'pnpm'
 }
 
 export default class WasmPackPlugin {

--- a/plugin.js
+++ b/plugin.js
@@ -46,6 +46,7 @@ class WasmPackPlugin {
     this.watchDirectories = (options.watchDirectories || [])
       .concat(path.resolve(this.crateDirectory, 'src'));
     this.watchFiles = [path.resolve(this.crateDirectory, 'Cargo.toml')];
+    this.packageManager = options.packageManager ? options.packageManager : 'npm';
 
     if (options.pluginLogLevel && options.pluginLogLevel !== 'info') {
       // The default value for pluginLogLevel is 'info'. If specified and it's
@@ -135,10 +136,12 @@ class WasmPackPlugin {
 
     info('ℹ️  Installing wasm-pack \n');
 
-    if (commandExistsSync("npm")) {
+    if (this.packageManager === 'npm' && commandExistsSync("npm")) {
       return runProcess("npm", ["install", "-g", "wasm-pack"], {});
-    } else if (commandExistsSync("yarn")) {
+    } else if (this.packageManager === 'yarn' && commandExistsSync("yarn")) {
       return runProcess("yarn", ["global", "add", "wasm-pack"], {});
+    } else if (this.packageManager === 'pnpm' && commandExistsSync("pnpm")) {
+      return runProcess("pnpm", ["add", "--global", "wasm-pack"], {});
     } else {
       error(
         "⚠️ could not install wasm-pack, you must have yarn or npm installed"


### PR DESCRIPTION
PNPM is getting popular ( and I am using it ) so this PR brings the ability to choose your package manager. By default, it is set to be 'npm` but the user can change that by configuring it in the `webpack.config.json` file

Signed-off-by: Daniel Maricic <daniel@woss.io>