### PR TITLE
Correctly report errors during the first compilation

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -107,16 +107,16 @@ class WasmPackPlugin {
         let first = true
 
         compiler.hooks.thisCompilation.tap('WasmPackPlugin', (compilation) => {
+            // This is needed in order to gracefully handle errors in Webpack,
+            // since Webpack has its own custom error system.
+            if (this.error != null) {
+                compilation.errors.push(this.error)
+            }
+
             // Super hacky, needed to workaround a bug in Webpack which causes
             // thisCompilation to be triggered twice on the first compilation.
             if (first) {
                 first = false
-            } else {
-                // This is needed in order to gracefully handle errors in Webpack,
-                // since Webpack has its own custom error system.
-                if (this.error != null) {
-                    compilation.errors.push(this.error)
-                }
             }
         })
     }


### PR DESCRIPTION
Errors are ignored the first time the Rust code is compiled. This causes
`yarn run build` on downstream projects to succeed even when compilation
actually failed.