### PR TITLE
add option to specify environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The minimum required `wasm-pack` version is `0.8.0`
 
 ## Linting
 
-This project uses the `prettier` with default configuration. Fo manually format the code run the `lint:fix` script.
+This project uses the `prettier` with default configuration. To manually format the code run the `lint:fix` script.
 
 ## Usage
 
@@ -79,7 +79,13 @@ module.exports = {
 
             // Controls plugin output verbosity, either 'info' or 'error'.
             // Defaults to 'info'.
-            // pluginLogLevel: 'info'
+            // pluginLogLevel: 'info',
+
+            // If defined, sets the specified environment variables during compilation.
+            //
+            // env: {
+            //   WASM_BINDGEN_THREADS_STACK_SIZE: 128 * 2 ** 10
+            // }
         }),
     ],
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -11,6 +11,7 @@ export interface WasmPackPluginOptions {
     watchDirectories?: string[]
     /** Controls plugin output verbosity. Defaults to 'info'. */
     pluginLogLevel?: 'info' | 'error'
+    env?: Record<string, string>
 }
 
 export default class WasmPackPlugin {

--- a/plugin.js
+++ b/plugin.js
@@ -64,6 +64,7 @@ class WasmPackPlugin {
         this.wp = new Watchpack()
         this.isDebug = true
         this.error = null
+        this.env = options.env
     }
 
     apply(compiler) {
@@ -123,7 +124,7 @@ class WasmPackPlugin {
 
     _makeEmpty() {
         try {
-            fs.mkdirSync(this.outDir, {recursive: true})
+            fs.mkdirSync(this.outDir, { recursive: true })
         } catch (e) {
             if (e.code !== 'EEXIST') {
                 throw e
@@ -178,6 +179,7 @@ class WasmPackPlugin {
                     cwd: this.crateDirectory,
                     args: this.args,
                     extraArgs: this.extraArgs,
+                    env: this.env,
                 })
             })
             .then((detail) => {
@@ -203,7 +205,15 @@ class WasmPackPlugin {
     }
 }
 
-function spawnWasmPack({ outDir, outName, isDebug, cwd, args, extraArgs }) {
+function spawnWasmPack({
+    outDir,
+    outName,
+    isDebug,
+    cwd,
+    args,
+    extraArgs,
+    env,
+}) {
     const bin = findWasmPack()
 
     const allArgs = [
@@ -220,6 +230,13 @@ function spawnWasmPack({ outDir, outName, isDebug, cwd, args, extraArgs }) {
     const options = {
         cwd,
         stdio: 'inherit',
+        env:
+            env != null
+                ? {
+                      ...process.env,
+                      ...env,
+                  }
+                : undefined,
     }
 
     return runProcess(bin, allArgs, options)


### PR DESCRIPTION
Some aspects of the post-compilation phase of `wasm-bindgen` can be configured through environment variables. There's really no way to control this from outside this plugin if you have separate crates with different settings.

Here we add an `env` option to pass environment variables to the `wasm-pack` execution.

Closes #147