### PR TITLE
feat: add stdio & stderr output to npm and yarn

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -145,9 +145,19 @@ class WasmPackPlugin {
         info('ℹ️  Installing wasm-pack \n')
 
         if (commandExistsSync('npm')) {
-            return runProcess('npm', ['install', '-g', 'wasm-pack'], {})
+            return runProcess('npm', ['install', '-g', 'wasm-pack'], {stdio: ['ignore', 'inherit', 'inherit']}).catch(e => {
+                error(
+                    '⚠️ could not install wasm-pack globally when using npm, you must have permission to do this'
+                )
+                throw e
+            })
         } else if (commandExistsSync('yarn')) {
-            return runProcess('yarn', ['global', 'add', 'wasm-pack'], {})
+            return runProcess('yarn', ['global', 'add', 'wasm-pack'], {stdio: ['ignore', 'inherit', 'inherit']}).catch(e => {
+                error(
+                    '⚠️ could not install wasm-pack globally when using yarn, you must have permission to do this'
+                )
+                throw e
+            })
         } else {
             error(
                 '⚠️ could not install wasm-pack, you must have yarn or npm installed'


### PR DESCRIPTION
Add stdio and stderr output to NPM and Yarn processs, when they go to globally install wasm-pack.

Add an error message if installing wasm-pack globally fails.

Resolves #138