### PR TITLE
Fix error spawn npm ENOENT on Windows

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -237,6 +237,7 @@ function spawnWasmPack({ outDir, outName, isDebug, cwd, args, extraArgs }) {
 
 function runProcess(bin, args, options) {
     return new Promise((resolve, reject) => {
+        options['shell'] = true
         const p = spawn(bin, args, options)
 
         p.on('close', (code) => {


### PR DESCRIPTION
On Windows, running `webpack` with this plugin added results in the following log:
```
> webpack

🧐  Checking for wasm-pack...

ℹ️  Installing wasm-pack 

⚠️ could not install wasm-pack globally when using npm, you must have permission to do this
[webpack-cli] Error: spawn npm ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn npm',
  path: 'npm',
  spawnargs: [ 'install', '-g', 'wasm-pack' ]
}
```

This seems to be because, by default, `spawn` on Windows will only look for `.exe` or `.com` files ([docs](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows))
However, `npm` is actually a `.cmd` file(similar to a `.bat`, an equivaent of a Linux shell script)
This can be fixed in a cross-platform way by enabling the `shell` option in `spawn`

There was a previous PR #122 which fixed this problem, however, it was closed by the author on the same day without a reason